### PR TITLE
Fix: Overlapping GitHub icon in username input #120

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1223,7 +1223,7 @@ function App() {
                     style={{
                       maxWidth: "300px",
                       width: "100%",
-                      padding: "12px 16px",
+                      padding: "12px 16px 12px 48px",
                       fontSize: "16px",
                       border: `1px solid ${colors.borderInput}`,
                       borderRadius: "8px",


### PR DESCRIPTION

## Description-
This PR resolves a minor but persistent UI bug in the "GitHub Username" input field.
Fixes #120 

## Screenshot
![Screenshot)](https://github.com/user-attachments/assets/25f9ee8b-668c-4a78-bd8c-8a4b5920fc72)


-> Could you please add the relevant label to the issue?