### PR TITLE
Fix studio nav runtime error and AOS/CSS parse warnings

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import AOS from 'aos';
-import 'aos/dist/aos.css';
 import NotFound from "./pages/NotFound.jsx";
 import {
   Frame,
@@ -34,6 +33,13 @@ const API_BASE_URL =
   (import.meta.env.PROD
     ? "https://github-avatar-frame-api.onrender.com"
     : "http://localhost:3001");
+
+const STUDIO_NAV_ITEMS = [
+  { label: "Start", target: "username-section" },
+  { label: "Customize", target: "settings-section" },
+  { label: "Generate", target: "generate-section" },
+  { label: "API Docs", target: `${API_BASE_URL}/api-docs`, external: true },
+];
 
 // Utility component for consistent button styling (Canvas and Shape)
 const ControlButton = ({ onClick, isSelected, children, isDark }) => (
@@ -483,6 +489,16 @@ function App() {
     { id: "text", label: "Text", helper: text.trim() || "Optional label" },
     { id: "emoji", label: "Emoji", helper: emojis.trim() || "Optional flair" },
   ];
+
+  const scrollToSection = useCallback((sectionId) => {
+    const section = document.getElementById(sectionId);
+
+    if (!section) {
+      return;
+    }
+
+    section.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
 
   // Detect system preference and set up listener
   useEffect(() => {
@@ -1064,7 +1080,7 @@ function App() {
             </div>
           </div>
           <div className="studio-navbar__links">
-            {studioNavItems.map((item) =>
+            {STUDIO_NAV_ITEMS.map((item) =>
               item.external ? (
                 <a key={item.label} href={item.target} target="_blank" rel="noopener noreferrer">
                   {item.label}

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -196,8 +196,10 @@ input:focus {
   .mono-box { background: rgba(255,255,255,0.02); }
 }
 
-::-webkit-scrollbar { width: 5px; }
-::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 10px; }
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar { width: 5px; }
+  ::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 10px; }
+}
 
 
 .responsive-stack {
@@ -344,5 +346,162 @@ input:focus {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* Minimal AOS-compatible animation rules. Kept local so the bundle does not
+   include AOS declarations with unitless transition-delay values that Firefox
+   reports as parse errors. */
+[data-aos] {
+  pointer-events: none;
+  transition-duration: 0.6s;
+  transition-property: opacity, transform;
+  transition-timing-function: ease-in-out;
+}
+
+[data-aos].aos-animate {
+  pointer-events: auto;
+}
+
+[data-aos="fade-down"] {
+  opacity: 0;
+  transform: translate3d(0, -24px, 0);
+}
+
+[data-aos="fade-up"] {
+  opacity: 0;
+  transform: translate3d(0, 24px, 0);
+}
+
+[data-aos="fade-right"] {
+  opacity: 0;
+  transform: translate3d(-24px, 0, 0);
+}
+
+[data-aos="zoom-in"] {
+  opacity: 0;
+  transform: scale(0.94);
+}
+
+[data-aos="flip-right"] {
+  opacity: 0;
+  transform: perspective(1200px) rotateY(-10deg);
+  backface-visibility: hidden;
+}
+
+[data-aos="flip-left"] {
+  opacity: 0;
+  transform: perspective(1200px) rotateY(10deg);
+  backface-visibility: hidden;
+}
+
+[data-aos].aos-animate {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-aos] {
+    opacity: 1;
+    transform: none;
+    transition-duration: 0.01s;
+  }
+}
+
+.studio-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 28px;
+  padding: 14px 16px;
+  border: 1px solid var(--border-light);
+  border-radius: 18px;
+  background: var(--glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: var(--shadow-sm);
+}
+
+.studio-navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 180px;
+}
+
+.studio-navbar__spark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 999px;
+  color: #fff;
+  background: linear-gradient(135deg, #7c3aed, #ec4899);
+}
+
+.studio-navbar__brand strong,
+.studio-navbar__brand small {
+  display: block;
+}
+
+.studio-navbar__brand strong {
+  font-size: 14px;
+  font-weight: 900;
+}
+
+.studio-navbar__brand small {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.studio-navbar__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.studio-navbar__links a,
+.studio-navbar__links button {
+  border: 1px solid rgba(124, 58, 237, 0.16);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #6d28d9;
+  background: rgba(124, 58, 237, 0.08);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.studio-navbar__links a:hover,
+.studio-navbar__links button:hover {
+  color: #fff;
+  background: #7c3aed;
+  transform: translateY(-1px);
+}
+
+@media (prefers-color-scheme: dark) {
+  .studio-navbar__links a,
+  .studio-navbar__links button {
+    color: #ddd6fe;
+    background: rgba(167, 139, 250, 0.14);
+    border-color: rgba(167, 139, 250, 0.2);
+  }
+}
+
+@media (max-width: 640px) {
+  .studio-navbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .studio-navbar__links {
+    justify-content: flex-start;
   }
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,14 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
-import AOS from 'aos'
-import 'aos/dist/aos.css'
 import './main.css'
-
-AOS.init({
-  duration: 1000, 
-  once: true,     
-});
 
 ReactDOM.createRoot(document.getElementById('root')).render(
 


### PR DESCRIPTION
### Motivation
- Prevent the runtime crash caused by an undefined `studioNavItems` reference in the Avatar Studio navbar.  
- Remove bundled AOS stylesheet behaviors that produce Firefox parse warnings for unitless `transition-delay` values and avoid unsupported `::-webkit-scrollbar` selector warnings.  
- Improve navbar UX by adding smooth internal scrolling and responsive styling for small screens.

### Description
- Added a top-level `STUDIO_NAV_ITEMS` constant and updated the navbar to render from `STUDIO_NAV_ITEMS` instead of the missing variable.  
- Implemented a `scrollToSection` handler (a `useCallback`) and wired navbar buttons to smoothly scroll to local section IDs.  
- Removed `aos/dist/aos.css` import and `AOS.init` from the React entry, and added a small, local set of AOS-compatible animation rules in `client/src/main.css` that avoid unitless `transition-delay` declarations.  
- Wrapped WebKit scrollbar rules in `@supports selector(::-webkit-scrollbar)` and added dedicated `.studio-navbar` styles for desktop and mobile layouts in `client/src/main.css`.

### Testing
- Ran `npm run lint --prefix client` and it completed successfully.  
- Built the client with `npm run build --prefix client` and the production bundle completed without build errors.  
- Ran a post-build validation script that checks built CSS for unitless `transition-delay: 0` occurrences and for bundled AOS delay rules, and the validation passed (no invalid unitless `transition-delay` or bundled AOS delay rules found).