### PR TITLE
Studio workspace: add navbar, responsive grid, and lightweight AOS styles

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import AOS from 'aos';
-import 'aos/dist/aos.css';
 import NotFound from "./pages/NotFound.jsx";
 import {
   Frame,
@@ -34,6 +33,14 @@ const API_BASE_URL =
   (import.meta.env.PROD
     ? "https://github-avatar-frame-api.onrender.com"
     : "http://localhost:3001");
+
+const STUDIO_NAV_ITEMS = [
+  { label: "Start", target: "username-section", icon: Github },
+  { label: "Preview", target: "preview-section", icon: Frame },
+  { label: "Customize", target: "settings-section", icon: Sparkles },
+  { label: "API Docs", target: `${API_BASE_URL}/api-docs`, icon: ChevronRight, external: true },
+  { label: "Generate", target: "generate-section", icon: Zap, cta: true },
+];
 
 // Utility component for consistent button styling (Canvas and Shape)
 const ControlButton = ({ onClick, isSelected, children, isDark }) => (
@@ -483,6 +490,16 @@ function App() {
     { id: "text", label: "Text", helper: text.trim() || "Optional label" },
     { id: "emoji", label: "Emoji", helper: emojis.trim() || "Optional flair" },
   ];
+
+  const scrollToSection = useCallback((sectionId) => {
+    const section = document.getElementById(sectionId);
+
+    if (!section) {
+      return;
+    }
+
+    section.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
 
   // Detect system preference and set up listener
   useEffect(() => {
@@ -1064,17 +1081,26 @@ function App() {
             </div>
           </div>
           <div className="studio-navbar__links">
-            {studioNavItems.map((item) =>
-              item.external ? (
-                <a key={item.label} href={item.target} target="_blank" rel="noopener noreferrer">
-                  {item.label}
+            {STUDIO_NAV_ITEMS.map((item) => {
+              const Icon = item.icon;
+              const className = item.cta ? "studio-navbar__link studio-navbar__link--cta" : "studio-navbar__link";
+              const content = (
+                <>
+                  <Icon size={16} aria-hidden="true" />
+                  <span>{item.label}</span>
+                </>
+              );
+
+              return item.external ? (
+                <a key={item.label} className={className} href={item.target} target="_blank" rel="noopener noreferrer">
+                  {content}
                 </a>
               ) : (
-                <button key={item.label} type="button" onClick={() => scrollToSection(item.target)}>
-                  {item.label}
+                <button key={item.label} className={className} type="button" onClick={() => scrollToSection(item.target)}>
+                  {content}
                 </button>
-              )
-            )}
+              );
+            })}
           </div>
         </nav>
 
@@ -1194,21 +1220,16 @@ function App() {
         </div>
 
       <div
-  className="main-grid-container"
+  className="main-grid-container studio-workspace-grid"
   style={{
-    display: "grid",
-    gap: "24px",
-    gridTemplateColumns: "1fr",
-    alignItems: "stretch",
-    justifyContent: "center",
-    maxWidth: "1040px",
+    maxWidth: "1120px",
     margin: "0 auto",
-    padding: "32px 16px",
   }}
 >
   {/* Configuration Panel */}
   <div 
     id="username-section" 
+    className="studio-panel studio-config-panel"
     data-aos="flip-right"
     style={{
       background: colors.bgCard,
@@ -2037,8 +2058,10 @@ function App() {
           </div>
 
           {/* Right: Preview Panel (50%) */}
-          <div data-aos="flip-left"
-            className="preview-panel-card"
+          <div
+            id="preview-section"
+            data-aos="flip-left"
+            className="studio-panel preview-panel-card studio-preview-panel"
             style={{
               background: colors.bgCard,
               borderRadius: "24px",

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -112,23 +112,56 @@ body {
    ========================== */
 .main-grid-container { 
   display: grid; 
-  grid-template-columns: 1fr; /* Force 1 column on mobile */
+  grid-template-columns: 1fr;
   gap: 32px; 
   align-items: start;
 }
 
-/* Tablet & Small Desktop (2 Equal Columns) */
-@media(min-width: 769px) {
-  .main-grid-container {
-    grid-template-columns: 1fr 1fr;
-  }
+.studio-workspace-grid {
+  grid-template-columns: minmax(320px, 1fr) minmax(320px, 0.9fr);
+  align-items: start;
+  gap: 24px;
+  justify-content: center;
+  padding: 32px 16px;
+}
+
+.studio-panel {
+  scroll-snap-align: start;
+}
+
+.studio-config-panel {
+  order: 1;
+}
+
+.studio-preview-panel {
+  order: 2;
 }
 
 /* Formal Wide Balance for Large Screens */
 @media(min-width: 1200px) {
-  .main-grid-container {
-    grid-template-columns: 1.1fr 0.9fr; 
+  .studio-workspace-grid {
+    grid-template-columns: minmax(0, 1.1fr) minmax(360px, 0.9fr); 
     gap: 48px;
+  }
+}
+
+@media(max-width: 768px) {
+  .studio-workspace-grid {
+    grid-template-columns: minmax(300px, 88vw) minmax(300px, 88vw);
+    justify-content: start;
+    overflow-x: auto;
+    overflow-y: visible;
+    scroll-padding-left: 16px;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .studio-config-panel {
+    order: 2;
+  }
+
+  .studio-preview-panel {
+    order: 1;
   }
 }
 
@@ -196,8 +229,10 @@ input:focus {
   .mono-box { background: rgba(255,255,255,0.02); }
 }
 
-::-webkit-scrollbar { width: 5px; }
-::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 10px; }
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar { width: 5px; }
+  ::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 10px; }
+}
 
 
 .responsive-stack {
@@ -344,5 +379,183 @@ input:focus {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* Minimal AOS-compatible animation rules. Kept local so the bundle does not
+   include AOS declarations with unitless transition-delay values that Firefox
+   reports as parse errors. */
+[data-aos] {
+  pointer-events: none;
+  transition-duration: 0.6s;
+  transition-property: opacity, transform;
+  transition-timing-function: ease-in-out;
+}
+
+[data-aos].aos-animate {
+  pointer-events: auto;
+}
+
+[data-aos="fade-down"] {
+  opacity: 0;
+  transform: translate3d(0, -24px, 0);
+}
+
+[data-aos="fade-up"] {
+  opacity: 0;
+  transform: translate3d(0, 24px, 0);
+}
+
+[data-aos="fade-right"] {
+  opacity: 0;
+  transform: translate3d(-24px, 0, 0);
+}
+
+[data-aos="zoom-in"] {
+  opacity: 0;
+  transform: scale(0.94);
+}
+
+[data-aos="flip-right"] {
+  opacity: 0;
+  transform: perspective(1200px) rotateY(-10deg);
+  backface-visibility: hidden;
+}
+
+[data-aos="flip-left"] {
+  opacity: 0;
+  transform: perspective(1200px) rotateY(10deg);
+  backface-visibility: hidden;
+}
+
+[data-aos].aos-animate {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-aos] {
+    opacity: 1;
+    transform: none;
+    transition-duration: 0.01s;
+  }
+}
+
+.studio-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 28px;
+  padding: 14px 16px;
+  border: 1px solid var(--border-light);
+  border-radius: 18px;
+  background: var(--glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: var(--shadow-sm);
+}
+
+.studio-navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 180px;
+}
+
+.studio-navbar__spark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 999px;
+  color: #fff;
+  background: linear-gradient(135deg, #7c3aed, #ec4899);
+}
+
+.studio-navbar__brand strong,
+.studio-navbar__brand small {
+  display: block;
+}
+
+.studio-navbar__brand strong {
+  font-size: 14px;
+  font-weight: 900;
+}
+
+.studio-navbar__brand small {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.studio-navbar__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.studio-navbar__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid rgba(124, 58, 237, 0.16);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #6d28d9;
+  background: rgba(124, 58, 237, 0.08);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.studio-navbar__link svg {
+  flex-shrink: 0;
+}
+
+.studio-navbar__link--cta {
+  color: #fff;
+  background: linear-gradient(135deg, #7c3aed, #ec4899);
+  border-color: transparent;
+  box-shadow: 0 10px 22px -14px rgba(124, 58, 237, 0.9);
+}
+
+.studio-navbar__link:hover {
+  color: #fff;
+  background: #7c3aed;
+  transform: translateY(-1px);
+}
+
+.studio-navbar__link--cta:hover {
+  background: linear-gradient(135deg, #6d28d9, #db2777);
+}
+
+@media (prefers-color-scheme: dark) {
+  .studio-navbar__link {
+    color: #ddd6fe;
+    background: rgba(167, 139, 250, 0.14);
+    border-color: rgba(167, 139, 250, 0.2);
+  }
+
+  .studio-navbar__link--cta {
+    color: #fff;
+    background: linear-gradient(135deg, #7c3aed, #ec4899);
+    border-color: transparent;
+  }
+}
+
+@media (max-width: 640px) {
+  .studio-navbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .studio-navbar__links {
+    justify-content: flex-start;
   }
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,14 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
-import AOS from 'aos'
-import 'aos/dist/aos.css'
 import './main.css'
-
-AOS.init({
-  duration: 1000, 
-  once: true,     
-});
 
 ReactDOM.createRoot(document.getElementById('root')).render(
 


### PR DESCRIPTION
### Motivation

- Provide a compact "Avatar Studio" workspace with a top navigation, predictable section scrolling, and improved two-column preview/config layout. 
- Make the UI responsive and mobile-friendly with panel ordering for small screens and a snapped horizontal scroll for narrow viewports. 
- Avoid bundling the full AOS stylesheet that caused parse issues in some browsers and keep small, explicit animation styles local to the app.

### Description

- Introduced `STUDIO_NAV_ITEMS` and a `scrollToSection` helper, and updated the navbar to render iconed links/buttons with CTA and external handling.  
- Converted the main layout to use `studio-workspace-grid` classes and added `id`/class attributes to key sections (`username-section`, `preview-section`) to enable section navigation and responsive ordering.  
- Added new CSS rules in `main.css` for the workspace grid, `.studio-navbar`, panel styles, responsive behavior, and a minimal set of `[data-aos]` animation rules; removed reliance on the external `aos/dist/aos.css`.  
- Removed `AOS.init()` and `aos` stylesheet imports from `main.jsx` and `App.jsx` to avoid global AOS CSS and initialization (local animation rules replace the dependency for basic effects).

### Testing

- Ran the project build via `npm run build` and the build completed successfully.  
- Ran linting via `npm run lint` and no lint errors were reported.
