### PR TITLE
Fix studio navbar rendering

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1087,11 +1087,11 @@ function App() {
                   {item.label}
                 </a>
               ) : (
-                <button key={item.label} className={className} type="button" onClick={() => scrollToSection(item.target)}>
-                  {content}
+                <button key={item.label} type="button" onClick={() => scrollToSection(item.target)}>
+                  {item.label}
                 </button>
-              );
-            })}
+              )
+            )}
           </div>
         </nav>
 


### PR DESCRIPTION
### Motivation
- Fix a client build failure caused by malformed JSX in the Avatar Studio navbar map callback and ensure internal nav buttons render correct labels.

### Description
- Modify `client/src/App.jsx` to correct the `STUDIO_NAV_ITEMS.map` callback by removing the invalid semicolon and replacing the undefined `className`/`content` usage with `item.label` for internal buttons.

### Testing
- Ran `npm test` which passed the server tests, and ran `npm run build:cli && (cd client && npm run build) && (cd client && npm run lint)` which completed successfully (client build and lint passed).
