### PR TITLE
Refactor header/dashboard UI, remove community modal and progress steps, and update styles

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -17,7 +17,6 @@ import {
   Square,
   Sun,
   Moon,
-  Users,
   X,
   Share2,
   Twitter,
@@ -34,13 +33,6 @@ const API_BASE_URL =
   (import.meta.env.PROD
     ? "https://github-avatar-frame-api.onrender.com"
     : "http://localhost:3001");
-
-const STUDIO_NAV_ITEMS = [
-  { label: "Start", target: "username-section" },
-  { label: "Customize", target: "settings-section" },
-  { label: "Generate", target: "generate-section" },
-  { label: "API Docs", target: `${API_BASE_URL}/api-docs`, external: true },
-];
 
 // Utility component for consistent button styling (Canvas and Shape)
 const ControlButton = ({ onClick, isSelected, children, isDark }) => (
@@ -88,120 +80,6 @@ const ControlButton = ({ onClick, isSelected, children, isDark }) => (
     {children}
   </button>
 );
-
-// --- Community Modal Component ---
-const CommunityModal = ({ isOpen, onClose, colors }) => {
-  if (!isOpen) return null;
-
-  // Fixed positioning and padding ensure the modal works on mobile without overflow
-  return (
-    <div
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: "rgba(0, 0, 0, 0.7)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 1000,
-        padding: "16px",
-        backdropFilter: "blur(5px)",
-      }}
-    >
-      <div
-        style={{
-          background: colors.bgCard,
-          borderRadius: "16px",
-          padding: "32px",
-          maxWidth: "450px",
-          width: "100%",
-          boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.5)",
-          position: "relative",
-          border: `1px solid ${colors.border}`,
-        }}
-      >
-        <button
-          onClick={onClose}
-          style={{
-            position: "absolute",
-            top: "12px",
-            right: "12px",
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-            color: colors.textSecondary,
-            transition: "color 0.2s",
-          }}
-          onMouseEnter={(e) =>
-            (e.currentTarget.style.color = colors.textPrimary)
-          }
-          onMouseLeave={(e) =>
-            (e.currentTarget.style.color = colors.textSecondary)
-          }
-        >
-          <X size={24} />
-        </button>
-
-        <div style={{ textAlign: "center", marginBottom: "24px" }}>
-          <Users
-            size={48}
-            color={colors.accentPrimary}
-            style={{ marginBottom: "12px" }}
-          />
-          <h3
-            style={{
-              fontSize: "24px",
-              fontWeight: "bold",
-              color: colors.textPrimary,
-              margin: 0,
-            }}
-          >
-            Join the Open Community
-          </h3>
-        </div>
-
-        <p
-          style={{
-            color: colors.textSecondary,
-            textAlign: "center",
-            marginBottom: "32px",
-          }}
-        >
-          This is where you'd find hundreds of custom themes, share your
-          creations, and collaborate on new frame designs!
-        </p>
-
-        <a
-          href="https://github.com/TechQuanta/github-avatar-frame-api" // Mock link
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={onClose}
-          style={{
-            display: "block",
-            width: "100%",
-            background: "linear-gradient(to right, #7c3aed, #a855f7)",
-            color: "white",
-            padding: "14px",
-            borderRadius: "8px",
-            textAlign: "center",
-            textDecoration: "none",
-            fontWeight: "600",
-            fontSize: "16px",
-            transition: "all 0.2s",
-            boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.opacity = 0.9)}
-          onMouseLeave={(e) => (e.currentTarget.style.opacity = 1)}
-        >
-          Visit Community Repository
-        </a>
-      </div>
-    </div>
-  );
-};
 
 // --- Share Modal Component ---
 const ShareModal = ({ isOpen, onClose, colors, shareUrl, username }) => {
@@ -430,9 +308,7 @@ function App() {
   const [framedAvatarUrl, setFramedAvatarUrl] = useState(null);
   const [previewKey, setPreviewKey] = useState(0);
   const [copied, setCopied] = useState(false);
-  const [currentStep, setCurrentStep] = useState(1);
   const [activeConfigTab, setActiveConfigTab] = useState("style");
-  const [isCommunityModalOpen, setIsCommunityModalOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState("");
   const [showToast, setShowToast] = useState(false);
 
@@ -462,7 +338,7 @@ function App() {
       textSecondary: isDark ? "#9ca3af" : "#6b7280",
       bgBody: isDark
         ? "#0F172A"
-        : "linear-gradient(135deg, #e0e7ff 0%, #f3e8ff 50%, #fce7f3 100%)",
+        : "linear-gradient(135deg, #f8fafc 0%, #eef2ff 55%, #faf5ff 100%)",
       bgCard: isDark ? "#1E293B" : "white",
       bgInput: isDark ? "#334155" : "white",
       border: isDark ? "#374151" : "#e5e7eb",
@@ -477,29 +353,11 @@ function App() {
     [isDark]
   );
 
-  // Progress Steps definition (using requested labels)
-  const steps = [
-    { num: 1, label: "Enter Username", icon: Github },
-    { num: 2, label: "Choose Theme", icon: Sparkles },
-    { num: 3, label: "Adjust Settings", icon: Zap },
-    { num: 4, label: "Generate", icon: Frame },
-  ];
-
   const configTabs = [
     { id: "style", label: "Style", helper: "Theme, color, size" },
     { id: "text", label: "Text", helper: text.trim() || "Optional label" },
     { id: "emoji", label: "Emoji", helper: emojis.trim() || "Optional flair" },
   ];
-
-  const scrollToSection = useCallback((sectionId) => {
-    const section = document.getElementById(sectionId);
-
-    if (!section) {
-      return;
-    }
-
-    section.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, []);
 
   // Detect system preference and set up listener
   useEffect(() => {
@@ -521,9 +379,6 @@ function App() {
       setRadius(maxRadius);
     }
 
-    if (username.trim() && selectedTheme) {
-      setCurrentStep(3);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [size, shape, maxRadius]);
 
@@ -626,8 +481,6 @@ function App() {
     setLoading(true);
     setError(null);
     setFramedAvatarUrl(null);
-    setCurrentStep(4);
-
     try {
       const finalRadius = shape === "circle" ? maxRadius : radius;
 
@@ -691,16 +544,10 @@ function App() {
   const handleUsernameChange = (e) => {
     setUsername(e.target.value);
     setPreviewError(null); // Clear preview error when username changes
-    if (e.target.value.trim()) {
-      setCurrentStep(2);
-    } else {
-      setCurrentStep(1);
-    }
   };
 
   const handleThemeSelect = (theme) => {
     setSelectedTheme(theme);
-    setCurrentStep(3);
     // Reset custom color when selecting a new theme
     setCustomAccentColor(null);
   };
@@ -725,7 +572,6 @@ function App() {
       showToastNotification("Surprise style loaded");
     }
     
-    setCurrentStep(3);
   };
 
   const showToastNotification = (message) => {
@@ -929,286 +775,31 @@ function App() {
                       maxWidth: "1200px",
                       margin:"0 auto",
                     }}>
-        {/* --- 1. Top Bar: Title + Community Button --- */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: "32px",
-            flexWrap: "wrap",
-            gap: "16px",
-          }}
-          className='header-container'
+        <section
+          className="dashboard-hero"
           data-aos="fade-down"
-          >
-          {/* Center Title Block */}
-          <div
-            style={{
-              flexGrow: 1,
-              textAlign: "center",
-              minWidth: "200px",
-              order: 1,
-              width: "100%",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: "12px",
-                marginBottom: "8px",
-              }}
-            >
-              <div style={{ position: "relative", display: "inline-block" }}>
-                <Frame
-                  size={48}
-                  color={colors.accentPrimary}
-                  strokeWidth={2.5}
-                />
-                <Sparkles
-                  size={20}
-                  color={colors.accentSecondary}
-                  className="pulse-icon"
-                  style={{
-                    position: "absolute",
-                    top: "-4px",
-                    right: "-4px",
-                  }}
-                />
-              </div>
-              <h1
-                className="main-title"
-                style={{
-                  fontSize: "48px",
-                  fontWeight: "900",
-                  fontFamily: "Georgia, Times New Roman, Times, serif",
-                  fontStyle: "italic",
-                  background:
-                    "linear-gradient(to right, #7c3aed, #a855f7, #ec4899)",
-                  WebkitBackgroundClip: "text",
-                  WebkitTextFillColor: "transparent",
-                  backgroundClip: "text",
-                  margin: 0,
-                }} data-aos="zoom-in">
-                GitHub Avatar Frames
-              </h1>
-            </div>
-            <p
-              style={{
-                color: colors.textSecondary,
-                fontSize: "16px",
-                margin: "0",
-              }}
-              data-aos="fade-right">
-                Create stunning framed avatars for your GitHub profile in seconds
+          style={{
+            background: colors.bgCard,
+            border: `1px solid ${colors.border}`,
+            color: colors.textPrimary,
+          }}
+        >
+          <div className="dashboard-hero__mark" aria-hidden="true">
+            <Frame size={30} strokeWidth={2.4} />
+          </div>
+          <div className="dashboard-hero__content">
+            <p className="dashboard-eyebrow">Avatar Dashboard</p>
+            <h1 className="dashboard-title">GitHub Avatar Frames</h1>
+            <p style={{ color: colors.textSecondary }}>
+              Create, preview, and export a polished GitHub avatar from one clean workspace.
             </p>
           </div>
-
-          {/* API Docs and Community Buttons */}
-          <div style={{ display: "flex", gap: "12px", alignItems: "center" }}>
-            <button data-aos="fade-right"
-              onClick={() => setIsCommunityModalOpen(true)}
-              className="community-button"
-              style={{
-                padding: "10px 20px",
-                borderRadius: "8px",
-                background: isDark ? "#374151" : "#f0f4f8",
-                border: `2px solid ${
-                  isDark ? colors.accentDark : colors.accentPrimary
-                }`,
-                color: isDark ? colors.accentDark : colors.accentPrimary,
-                fontWeight: "800",
-                fontSize: "14px",
-                cursor: "pointer",
-                transition: "all 0.3s",
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-                boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = isDark
-                  ? "#475569"
-                  : colors.accentPrimary;
-                e.currentTarget.style.color = isDark ? "white" : "white";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = isDark ? "#374151" : "#f0f4f8";
-                e.currentTarget.style.color = isDark
-                  ? colors.accentDark
-                  : colors.accentPrimary;
-              }}
-            >
-              <Users size={20} />
-              <span style={{ fontFamily: "Times New Roman, serif" }}>
-                Open Community
-              </span>
-            </button>
-            <a
-              href={`${API_BASE_URL}/api-docs`}
-              target="_blank"
-              rel="noopener noreferrer"
-              data-aos="fade-right"
-              style={{
-                padding: "10px 20px",
-                borderRadius: "8px",
-                background: isDark ? "#374151" : "#f0f4f8",
-                border: `2px solid ${isDark ? colors.accentDark : colors.accentPrimary}`,
-                color: isDark ? colors.accentDark : colors.accentPrimary,
-                fontWeight: "700",
-                fontSize: "14px",
-                textDecoration: "none",
-                transition: "all 0.3s",
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-                boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-              }}
-            >
-              API Docs
-            </a>
+          <div className="dashboard-hero__meta" aria-label="Dashboard summary">
+            <span>{themes.length || "—"} themes</span>
+            <span>{size}px canvas</span>
+            <span>{selectedTheme}</span>
           </div>
-        </div>
-
-        <nav className="studio-navbar" data-aos="fade-up" aria-label="Avatar studio navigation">
-          <div className="studio-navbar__brand">
-            <span className="studio-navbar__spark">✦</span>
-            <div>
-              <strong>Avatar Studio</strong>
-              <small>Build • Preview • Share</small>
-            </div>
-          </div>
-          <div className="studio-navbar__links">
-            {STUDIO_NAV_ITEMS.map((item) =>
-              item.external ? (
-                <a key={item.label} href={item.target} target="_blank" rel="noopener noreferrer">
-                  {item.label}
-                </a>
-              ) : (
-                <button key={item.label} className={className} type="button" onClick={() => scrollToSection(item.target)}>
-                  {content}
-                </button>
-              );
-            })}
-          </div>
-        </nav>
-
-        {/* --- 2. Progress Steps --- */}
-        <div data-aos="fade-right" style={{ marginBottom: "32px" }}>
-          <div
-            style={{
-              background: colors.bgCard,
-              borderRadius: "12px",
-              padding: "20px",
-              border: `1px solid ${colors.border}`,
-              maxWidth: "100%",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                flexWrap: "wrap",
-              }}
-            >
-              {steps.map((step, idx) => {
-                const isActive = currentStep >= step.num;
-                const Icon = step.icon;
-
-                  const activeBg = "white"; 
-                  const inactiveBg = isDark ? "#374151" : "#f3f4f6";
-                  const activeColor = "#111827"; 
-                  const inactiveColor = "white";  
-                   const activeBorder = "#a855f7"; 
-                   const inactiveBorder = isDark ? "#4b5563" : "#e5e7eb";
-
-                return (
-                  <React.Fragment key={step.num}>
-                    <div
-                      style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "center",
-                        flex: 1,
-                        minWidth: "20%",
-                      }}
-                    >
-                      <div
-
-                       onClick={() => {
-    const sectionIds = [
-      "#username-section",
-      "#theme-section",
-      "#settings-section",
-      "#generate-section",
-    ];
-    const targetId = sectionIds[idx];
-    if (step.num === 3) setActiveConfigTab("style");
-    const target = document.querySelector(targetId);
-    if (target) target.scrollIntoView({ behavior: "smooth", block: "start" });
-  }}
-  style={{
-    width: "48px",
-    height: "48px",
-    borderRadius: "50%",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: "8px",
-    transition: "all 0.3s ease",
-    background: isActive ? activeBg : inactiveBg,
-    color: isActive ? activeColor : inactiveColor,
-    border: `2px solid ${
-      isActive ? activeBorder : inactiveBorder
-    }`,
-    cursor: "pointer",
-  }}
-  onMouseEnter={(e) => {
-    e.currentTarget.style.transform = "scale(1.1)";
-    e.currentTarget.style.boxShadow =
-      "0 0 10px rgba(168, 85, 247, 0.5)";
-       if (!isActive) {
-              e.currentTarget.style.background = "white"; 
-              e.currentTarget.style.color = "#111827"; 
-            }
-  }}
-  onMouseLeave={(e) => {
-    e.currentTarget.style.transform = "scale(1)";
-    e.currentTarget.style.boxShadow = "none";
-    if (!isActive) {
-              e.currentTarget.style.background = inactiveBg;
-              e.currentTarget.style.color = inactiveColor; 
-            }
-  }}
->
-
-                        <Icon size={20} />
-                      </div>
-                      <div
-                        style={{
-                          fontSize: "12px",
-                          fontWeight: "600",
-                          textAlign: "center",
-
-                          // color: isActive ? activeColor : inactiveColor,
-                           color: isActive ? "white" : "#9ca3af"
-                        }}>
-
-                        
-
-                        {step.label}
-                      </div>
-                    </div>
-
-                  </React.Fragment>
-                );
-              })}
-            </div>
-          </div>
-        </div>
+        </section>
 
       <div
   className="main-grid-container studio-workspace-grid"
@@ -1263,7 +854,7 @@ function App() {
           margin: 0,
         }}
       >
-        Configuration & Params
+        Dashboard Controls
       </h2>
     </div>
 
@@ -2519,13 +2110,6 @@ function App() {
         </div>
       </div>
 
-      {/* Community Modal Injection */}
-      <CommunityModal
-        isOpen={isCommunityModalOpen}
-        onClose={() => setIsCommunityModalOpen(false)}
-        colors={colors}
-      />
-
       {/* Share Modal Injection */}
       <ShareModal
         isOpen={isShareModalOpen}
@@ -2578,8 +2162,6 @@ function App() {
         </div>
       )}
 
-      {/* Styles are provided by ./App.css */}
-      {/* Community Modal */}
     </div>
   } />
   <Route path="*" element={<NotFound />} />

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -56,31 +56,97 @@ body {
   .layout-wrapper { padding: 24px 16px; }
 }
 
-/* Fixed Header Responsiveness */
-.header-container { 
-  display: flex; 
-  flex-direction: column; /* Stacked on mobile */
-  justify-content: flex-start; 
-  align-items: flex-start; 
-  gap: 20px; 
-  margin-bottom: 48px;
+/* ==========================
+    Single Dashboard Header
+   ========================== */
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 20px;
+  margin: 0 auto 28px;
+  max-width: 1120px;
+  padding: 24px;
+  border-radius: 28px;
+  box-shadow: var(--shadow-sm);
 }
 
-@media(min-width: 768px) {
-  .header-container { 
-    flex-direction: row; /* Side-by-side on desktop */
-    justify-content: space-between; 
-    align-items: flex-end; 
+.dashboard-hero__mark {
+  display: grid;
+  width: 64px;
+  height: 64px;
+  place-items: center;
+  border-radius: 20px;
+  color: #fff;
+  background: linear-gradient(135deg, #7c3aed, #ec4899);
+  box-shadow: 0 18px 36px rgba(124, 58, 237, 0.22);
+}
+
+.dashboard-hero__content {
+  min-width: 0;
+}
+
+.dashboard-eyebrow {
+  margin: 0 0 6px;
+  color: #7c3aed;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.dashboard-title {
+  margin: 0;
+  font-size: clamp(30px, 5vw, 48px);
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+
+.dashboard-hero__content p:last-child {
+  margin: 10px 0 0;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.dashboard-hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.dashboard-hero__meta span {
+  border: 1px solid rgba(124, 58, 237, 0.16);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #6d28d9;
+  background: rgba(124, 58, 237, 0.08);
+  font-size: 12px;
+  font-weight: 900;
+}
+
+@media (prefers-color-scheme: dark) {
+  .dashboard-eyebrow {
+    color: #ddd6fe;
+  }
+
+  .dashboard-hero__meta span {
+    color: #ddd6fe;
+    background: rgba(167, 139, 250, 0.14);
+    border-color: rgba(167, 139, 250, 0.2);
   }
 }
 
-.main-title { 
-  font-size: clamp(32px, 8vw, 60px); 
-  font-weight: 900;
-  letter-spacing: -0.05em;
-  line-height: 0.9;
-  margin: 0;
-  text-transform: uppercase;
+@media(max-width: 768px) {
+  .dashboard-hero {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+
+  .dashboard-hero__meta {
+    justify-content: flex-start;
+  }
 }
 
 /* ==========================
@@ -438,103 +504,5 @@ input:focus {
     opacity: 1;
     transform: none;
     transition-duration: 0.01s;
-  }
-}
-
-.studio-navbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin: 0 0 28px;
-  padding: 14px 16px;
-  border: 1px solid var(--border-light);
-  border-radius: 18px;
-  background: var(--glass);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  box-shadow: var(--shadow-sm);
-}
-
-.studio-navbar__brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 180px;
-}
-
-.studio-navbar__spark {
-  display: grid;
-  width: 36px;
-  height: 36px;
-  place-items: center;
-  border-radius: 999px;
-  color: #fff;
-  background: linear-gradient(135deg, #7c3aed, #ec4899);
-}
-
-.studio-navbar__brand strong,
-.studio-navbar__brand small {
-  display: block;
-}
-
-.studio-navbar__brand strong {
-  font-size: 14px;
-  font-weight: 900;
-}
-
-.studio-navbar__brand small {
-  margin-top: 2px;
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 700;
-}
-
-.studio-navbar__links {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.studio-navbar__links a,
-.studio-navbar__links button {
-  border: 1px solid rgba(124, 58, 237, 0.16);
-  border-radius: 999px;
-  padding: 8px 12px;
-  color: #6d28d9;
-  background: rgba(124, 58, 237, 0.08);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 800;
-  text-decoration: none;
-  cursor: pointer;
-  transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease;
-}
-
-.studio-navbar__links a:hover,
-.studio-navbar__links button:hover {
-  color: #fff;
-  background: #7c3aed;
-  transform: translateY(-1px);
-}
-
-@media (prefers-color-scheme: dark) {
-  .studio-navbar__links a,
-  .studio-navbar__links button {
-    color: #ddd6fe;
-    background: rgba(167, 139, 250, 0.14);
-    border-color: rgba(167, 139, 250, 0.2);
-  }
-}
-
-@media (max-width: 640px) {
-  .studio-navbar {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .studio-navbar__links {
-    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
### Motivation
- Simplify the top-level UI into a single dashboard hero and reduce visual clutter by removing the multi-step progress and community modal code.
- Modernize header styling and make the hero responsive and theme-aware for both light and dark modes.
- Clean up unused imports and state related to the removed UI pieces to reduce maintenance surface.

### Description
- Removed the `CommunityModal` component, the studio navigation (`STUDIO_NAV_ITEMS`), the progress `steps` and the `currentStep` state and all related click/scroll logic such as `scrollToSection` and step-based transitions.
- Replaced the previous header and studio navbar markup with a new `dashboard-hero` section and updated the main header text/content to a compact dashboard layout in `client/src/App.jsx`.
- Updated theme colors and background gradient in the `colors` memo (light background gradient adjusted) and removed the `Users` icon import from `lucide-react`.
- Reworked styles in `client/src/main.css` by adding `.dashboard-hero*` classes and removing the old `.header-container` and `.studio-navbar` CSS blocks to reflect the new header and meta chips layout.
- Removed injection/usage of the community modal from the render tree and updated a few UI strings (for example `Configuration & Params` -> `Dashboard Controls`) and minor refactors to theme-randomization flow to no longer advance removed steps.

### Testing
- Performed an automated production build via `npm run build` which completed successfully with the updated client files.
- No automated unit tests were added or modified as part of this change.
