### PR TITLE
Fix ReferenceError from missing STUDIO_NAV_ITEMS in dashboard hero

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -787,19 +787,6 @@ function App() {
           <div className="dashboard-hero__mark" aria-hidden="true">
             <Frame size={30} strokeWidth={2.4} />
           </div>
-          <div className="studio-navbar__links">
-            {STUDIO_NAV_ITEMS.map((item) =>
-              item.external ? (
-                <a key={item.label} href={item.target} target="_blank" rel="noopener noreferrer">
-                  {item.label}
-                </a>
-              ) : (
-                <button key={item.label} type="button" onClick={() => scrollToSection(item.target)}>
-                  {item.label}
-                </button>
-              )
-            )}
-          </div>
           <div className="dashboard-hero__meta" aria-label="Dashboard summary">
             <span>{themes.length || "—"} themes</span>
             <span>{size}px canvas</span>


### PR DESCRIPTION
### Motivation
- The dashboard rendered a navigation block that referenced the removed global `STUDIO_NAV_ITEMS`, causing a runtime `ReferenceError` in production.

### Description
- Removed the dashboard hero navigation JSX that mapped over `STUDIO_NAV_ITEMS` from `client/src/App.jsx` so the hero renders without evaluating the missing global.
- Kept the dashboard mark and metadata (`themes`, `size`, `selectedTheme`) intact to preserve the hero summary layout.

### Testing
- Ran `npm test`, which executed the test suite and reported all tests passed (4 passed, 0 failed).
- Built the client with `cd client && npm run build`, which completed successfully (Vite production build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9b09826c83309cefe49668a4f17f)