### PR TITLE
Add Studio layout: StudioPageShell, DashboardHero, and responsive studio styles

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -25,6 +25,8 @@ import {
   Palette,
 } from "lucide-react";
 import ThemeSlider from "./components/ThemeSlider.jsx";
+import DashboardHero from "./components/studio/DashboardHero.jsx";
+import StudioPageShell from "./components/studio/StudioPageShell.jsx";
 
 // Use an explicit Vite env override when provided; otherwise default to the
 // deployed API in production and the local API server during development.
@@ -343,9 +345,9 @@ function App() {
       bgInput: isDark ? "#334155" : "white",
       border: isDark ? "#374151" : "#e5e7eb",
       borderInput: isDark ? "#475569" : "#d1d5db",
-      accentPrimary: "#7c3aed",
-      accentSecondary: "#a855f7",
-      accentDark: "#a78bfa",
+      accentPrimary: "#8b5cf6",
+      accentSecondary: "#06b6d4",
+      accentDark: "#22d3ee",
       errorBg: isDark ? "#450a0a" : "#fef2f2",
       errorBorder: isDark ? "#b91c1c" : "#fecaca",
       errorText: isDark ? "#fca5a5" : "#991b1b",
@@ -763,55 +765,19 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={
-          <div
-            style={{
-              minHeight: "100vh",
-              background: colors.bgBody,
-              padding: "24px 16px",
-              color: colors.textPrimary,
-            }}>
-            <div className="layout-wrapper"
-                    style={{
-                      maxWidth: "1200px",
-                      margin:"0 auto",
-                    }}>
-        <section
-          className="dashboard-hero"
-          data-aos="fade-down"
-          style={{
-            background: colors.bgCard,
-            border: `1px solid ${colors.border}`,
-            color: colors.textPrimary,
-          }}
-        >
-          <div className="dashboard-hero__mark" aria-hidden="true">
-            <Frame size={30} strokeWidth={2.4} />
-          </div>
-          <div className="studio-navbar__links">
-            {STUDIO_NAV_ITEMS.map((item) =>
-              item.external ? (
-                <a key={item.label} href={item.target} target="_blank" rel="noopener noreferrer">
-                  {item.label}
-                </a>
-              ) : (
-                <button key={item.label} type="button" onClick={() => scrollToSection(item.target)}>
-                  {item.label}
-                </button>
-              )
-            )}
-          </div>
-          <div className="dashboard-hero__meta" aria-label="Dashboard summary">
-            <span>{themes.length || "—"} themes</span>
-            <span>{size}px canvas</span>
-            <span>{selectedTheme}</span>
-          </div>
-        </section>
+          <StudioPageShell colors={colors}>
+            <DashboardHero
+              colors={colors}
+              themesCount={themes.length}
+              selectedTheme={selectedTheme}
+              size={size}
+            />
 
       <div
   className="main-grid-container studio-workspace-grid"
   style={{
-    maxWidth: "1120px",
-    margin: "0 auto",
+    maxWidth: "100%",
+    margin: "0",
   }}
 >
   {/* Configuration Panel */}
@@ -823,7 +789,7 @@ function App() {
       background: colors.bgCard,
       borderRadius: "24px",
       border: `1px solid ${colors.border}`,
-      padding: "32px",
+      padding: "clamp(16px, 2vw, 24px)",
       backgroundImage: isDark
         ? "radial-gradient(circle at top right, rgba(168, 85, 247, 0.18), transparent 34%)"
         : "radial-gradient(circle at top right, rgba(168, 85, 247, 0.16), transparent 34%)",
@@ -1654,7 +1620,7 @@ function App() {
               background: colors.bgCard,
               borderRadius: "24px",
               border: `1px solid ${colors.border}`,
-              padding: "32px",
+              padding: "clamp(16px, 2vw, 24px)",
               maxWidth: "100%",
               minWidth: "0",
               backgroundImage: isDark
@@ -2114,7 +2080,6 @@ function App() {
             </div>
           </div>
         </div>
-      </div>
 
       {/* Share Modal Injection */}
       <ShareModal
@@ -2168,7 +2133,7 @@ function App() {
         </div>
       )}
 
-    </div>
+    </StudioPageShell>
   } />
   <Route path="*" element={<NotFound />} />
   </Routes>

--- a/client/src/components/studio/DashboardHero.jsx
+++ b/client/src/components/studio/DashboardHero.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Frame, Github, Palette, Download } from "lucide-react";
+
+const WORKFLOW_STEPS = [
+  { label: "1. Username", icon: Github },
+  { label: "2. Style", icon: Palette },
+  { label: "3. Export", icon: Download },
+];
+
+function DashboardHero({ colors, themesCount, selectedTheme, size }) {
+  return (
+    <section
+      className="dashboard-hero studio-dashboard-hero"
+      data-aos="fade-down"
+      style={{
+        background: colors.bgCard,
+        border: `1px solid ${colors.border}`,
+        color: colors.textPrimary,
+      }}
+    >
+      <div className="dashboard-hero__mark" aria-hidden="true">
+        <Frame size={30} strokeWidth={2.4} />
+      </div>
+
+      <div className="dashboard-hero__content">
+        <p className="dashboard-eyebrow">Avatar Frame Studio</p>
+        <h1 className="dashboard-title">GitAvatar Frame Creator</h1>
+        <p className="dashboard-subtitle">Design, preview, and export in one flow.</p>
+      </div>
+
+      <div className="studio-workflow" aria-label="Avatar creation workflow">
+        {WORKFLOW_STEPS.map(({ label, icon }, index) => (
+          <div className="studio-workflow__step" key={label}>
+            <span className="studio-workflow__icon">
+              {React.createElement(icon, { size: 15 })}
+            </span>
+            <span>{label}</span>
+            {index < WORKFLOW_STEPS.length - 1 && <span className="studio-workflow__line" />}
+          </div>
+        ))}
+      </div>
+
+      <div className="dashboard-hero__meta" aria-label="Dashboard summary">
+        <span>{themesCount || "—"} themes</span>
+        <span>{size}px canvas</span>
+        <span>{selectedTheme}</span>
+      </div>
+    </section>
+  );
+}
+
+export default DashboardHero;

--- a/client/src/components/studio/StudioPageShell.jsx
+++ b/client/src/components/studio/StudioPageShell.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+function StudioPageShell({ colors, children }) {
+  return (
+    <main
+      className="studio-page"
+      style={{
+        background: colors.bgBody,
+        color: colors.textPrimary,
+      }}
+    >
+      <div className="layout-wrapper studio-page__layout">{children}</div>
+    </main>
+  );
+}
+
+export default StudioPageShell;

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -506,3 +506,442 @@ input:focus {
     transition-duration: 0.01s;
   }
 }
+
+/* ==========================
+    Single-page Studio Layout
+   ========================== */
+#root {
+  min-height: 100dvh;
+}
+
+.studio-page {
+  min-height: 100dvh;
+  padding: 12px;
+  background-attachment: fixed;
+}
+
+.studio-page__layout {
+  width: min(100%, 1440px);
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.studio-dashboard-hero {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: clamp(14px, 1.5vw, 20px);
+  grid-template-columns: auto minmax(220px, 1fr) auto auto;
+  gap: clamp(12px, 1.4vw, 20px);
+  overflow: hidden;
+}
+
+.studio-dashboard-hero .dashboard-hero__mark {
+  width: clamp(48px, 4.4vw, 60px);
+  height: clamp(48px, 4.4vw, 60px);
+  border-radius: 18px;
+}
+
+.studio-dashboard-hero .dashboard-title {
+  max-width: 760px;
+  font-size: clamp(22px, 2.3vw, 34px);
+  line-height: 1.05;
+}
+
+.studio-workflow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid rgba(124, 58, 237, 0.14);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.08), rgba(236, 72, 153, 0.08));
+  white-space: nowrap;
+}
+
+.studio-workflow__step {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #6d28d9;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.studio-workflow__icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 50%;
+  color: white;
+  background: linear-gradient(135deg, #7c3aed, #ec4899);
+}
+
+.studio-workflow__line {
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(124, 58, 237, 0.3);
+}
+
+.studio-workspace-grid {
+  width: 100%;
+  padding: 0;
+  gap: clamp(12px, 1.5vw, 20px);
+  align-items: stretch;
+}
+
+.studio-config-panel,
+.studio-preview-panel {
+  min-height: 0;
+  box-shadow: 0 24px 80px -48px rgba(15, 23, 42, 0.55), 0 8px 26px -22px rgba(124, 58, 237, 0.45) !important;
+}
+
+.studio-config-panel {
+  overflow: auto;
+}
+
+.studio-config-panel > div:first-child,
+.studio-preview-panel > div:first-child {
+  margin-bottom: 4px !important;
+}
+
+.search-theme-container {
+  gap: 14px !important;
+  margin-bottom: 0 !important;
+}
+
+.interactive-tab-shell {
+  top: 0;
+  margin-bottom: 6px !important;
+}
+
+.config-tab-button {
+  min-height: 52px;
+}
+
+.control-group,
+.tab-panel {
+  margin-bottom: 12px !important;
+}
+
+.generate-action-bar {
+  bottom: 0;
+  margin-top: auto;
+}
+
+.studio-preview-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.studio-preview-panel > div:last-child {
+  flex: 1;
+  min-height: 0 !important;
+}
+
+.studio-preview-panel .preview-canvas,
+.studio-preview-panel .preview-img {
+  max-width: min(100%, 420px);
+  max-height: min(46vh, 420px);
+  margin: 0 auto;
+  object-fit: contain;
+}
+
+@media (prefers-color-scheme: dark) {
+  .studio-workflow {
+    border-color: rgba(167, 139, 250, 0.2);
+    background: linear-gradient(135deg, rgba(167, 139, 250, 0.14), rgba(244, 114, 182, 0.12));
+  }
+
+  .studio-workflow__step {
+    color: #ddd6fe;
+  }
+
+  .studio-workflow__line {
+    background: rgba(221, 214, 254, 0.32);
+  }
+}
+
+@media (min-width: 900px) {
+  html,
+  body,
+  #root {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .studio-page {
+    height: 100dvh;
+    overflow: hidden;
+  }
+
+  .studio-page__layout {
+    height: 100%;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .studio-workspace-grid {
+    min-height: 0;
+    grid-template-columns: minmax(540px, 1.18fr) minmax(360px, 0.82fr);
+  }
+
+  .studio-config-panel,
+  .studio-preview-panel {
+    height: 100%;
+  }
+
+  .preview-panel-card {
+    max-height: none;
+  }
+}
+
+@media (max-width: 1180px) {
+  .studio-dashboard-hero {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .studio-workflow {
+    display: none;
+  }
+}
+
+@media (max-width: 899px) {
+  html,
+  body,
+  #root {
+    min-height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  .studio-page {
+    min-height: 100dvh;
+    overflow: visible;
+    padding: 12px;
+  }
+
+  .studio-page__layout {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .studio-dashboard-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .studio-workspace-grid {
+    grid-template-columns: 1fr;
+    overflow: visible;
+    scroll-snap-type: none;
+  }
+
+  .studio-config-panel,
+  .studio-preview-panel {
+    order: initial;
+    overflow: visible;
+  }
+
+  .studio-preview-panel .preview-canvas,
+  .studio-preview-panel .preview-img {
+    max-height: none;
+  }
+}
+
+/* ==========================
+    Polished Studio Theme + Scrollbars
+   ========================== */
+:root {
+  --studio-purple: #8b5cf6;
+  --studio-purple-deep: #6d28d9;
+  --studio-cyan: #06b6d4;
+  --studio-pink: #ec4899;
+  --studio-ink: #172033;
+  --studio-scroll-track: rgba(139, 92, 246, 0.09);
+  --studio-scroll-thumb: linear-gradient(180deg, var(--studio-purple), var(--studio-cyan));
+  --accent-primary: var(--studio-purple);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --studio-scroll-track: rgba(255, 255, 255, 0.07);
+  }
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--studio-purple) transparent;
+}
+
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: var(--studio-scroll-track);
+    border-radius: 999px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    min-height: 52px;
+    border: 2px solid transparent;
+    border-radius: 999px;
+    background: var(--studio-scroll-thumb) border-box;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: linear-gradient(180deg, var(--studio-purple-deep), var(--studio-pink)) border-box;
+  }
+}
+
+.studio-page {
+  background-image:
+    radial-gradient(circle at 8% 12%, rgba(139, 92, 246, 0.18), transparent 28%),
+    radial-gradient(circle at 88% 8%, rgba(6, 182, 212, 0.16), transparent 28%),
+    radial-gradient(circle at 70% 92%, rgba(236, 72, 153, 0.12), transparent 32%);
+}
+
+.studio-dashboard-hero {
+  position: relative;
+  isolation: isolate;
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.86), rgba(245, 243, 255, 0.72)) !important;
+  box-shadow: 0 24px 70px -48px rgba(76, 29, 149, 0.7), 0 10px 34px -28px rgba(6, 182, 212, 0.7);
+}
+
+.studio-dashboard-hero::after {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(139, 92, 246, 0.12), rgba(6, 182, 212, 0.08), rgba(236, 72, 153, 0.1));
+  content: "";
+}
+
+.studio-dashboard-hero .dashboard-hero__mark,
+.studio-workflow__icon {
+  background: linear-gradient(135deg, var(--studio-purple), var(--studio-cyan));
+  box-shadow: 0 18px 34px rgba(6, 182, 212, 0.2), 0 10px 30px rgba(139, 92, 246, 0.24);
+}
+
+.dashboard-eyebrow {
+  color: var(--studio-purple-deep);
+}
+
+.dashboard-title {
+  color: var(--studio-ink);
+}
+
+.dashboard-subtitle {
+  max-width: 560px;
+  margin: 8px 0 0;
+  color: #536179;
+  font-size: clamp(13px, 1.25vw, 16px);
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.studio-dashboard-hero .dashboard-hero__meta span,
+.config-summary-strip span {
+  color: var(--studio-purple-deep);
+  background: rgba(139, 92, 246, 0.1);
+  border-color: rgba(139, 92, 246, 0.18);
+}
+
+.studio-workflow {
+  border-color: rgba(6, 182, 212, 0.2);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.1), rgba(6, 182, 212, 0.1));
+}
+
+.studio-workflow__step {
+  color: var(--studio-purple-deep);
+}
+
+.studio-workflow__line {
+  background: linear-gradient(90deg, rgba(139, 92, 246, 0.36), rgba(6, 182, 212, 0.46));
+}
+
+.studio-config-panel,
+.studio-preview-panel {
+  scrollbar-gutter: stable;
+}
+
+.studio-config-panel::-webkit-scrollbar,
+.studio-preview-panel::-webkit-scrollbar {
+  width: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .studio-dashboard-hero {
+    background-image: linear-gradient(135deg, rgba(30, 41, 59, 0.94), rgba(15, 23, 42, 0.9)) !important;
+    box-shadow: 0 24px 70px -44px rgba(6, 182, 212, 0.34), 0 10px 34px -26px rgba(139, 92, 246, 0.52);
+  }
+
+  .dashboard-title {
+    color: #f8fafc;
+  }
+
+  .dashboard-subtitle {
+    color: #b8c2d8;
+  }
+
+  .dashboard-eyebrow,
+  .studio-workflow__step,
+  .studio-dashboard-hero .dashboard-hero__meta span,
+  .config-summary-strip span {
+    color: #cffafe;
+  }
+
+  .studio-dashboard-hero .dashboard-hero__meta span,
+  .config-summary-strip span {
+    background: rgba(6, 182, 212, 0.12);
+    border-color: rgba(34, 211, 238, 0.22);
+  }
+}
+
+@media (max-width: 899px) {
+  .studio-dashboard-hero {
+    gap: 14px;
+  }
+
+  .studio-dashboard-hero .dashboard-hero__meta {
+    justify-content: flex-start;
+  }
+
+  .dashboard-subtitle {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .studio-page {
+    padding: 8px;
+  }
+
+  .studio-dashboard-hero {
+    border-radius: 22px;
+    padding: 16px;
+  }
+
+  .studio-dashboard-hero .dashboard-hero__mark {
+    width: 46px;
+    height: 46px;
+    border-radius: 15px;
+  }
+
+  .dashboard-title {
+    font-size: clamp(25px, 9vw, 34px);
+  }
+
+  .dashboard-hero__meta span {
+    padding: 7px 10px;
+    font-size: 11px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce a focused single-page "Studio" workspace to surface avatar creation flow and improve layout readability.
- Encapsulate the studio page scaffold and hero UI into reusable components for cleaner `App.jsx` and easier future iteration.
- Refresh the studio color accents and responsive paddings to improve visual polish across screen sizes.

### Description
- Added `DashboardHero` (`client/src/components/studio/DashboardHero.jsx`) to render the studio hero, workflow steps, and summary meta.
- Added `StudioPageShell` (`client/src/components/studio/StudioPageShell.jsx`) to wrap the studio content and centralize page-level styles.
- Refactored `client/src/App.jsx` to mount the studio via `<StudioPageShell>` and `<DashboardHero>` and adjusted several inline styles (padding, max widths, accent colors) to integrate with the new layout.
- Expanded `client/src/main.css` with a large set of responsive studio styles, theming variables, polished scrollbars, and layout rules for the new studio UI.

### Testing
- Ran a production build via `npm run build` which completed successfully.
- Ran linting checks via `npm run lint` which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9b09826c83309cefe49668a4f17f)